### PR TITLE
Run python.wasm via Wasmtime PHP extension

### DIFF
--- a/.github/workflows/wasmtime.yml
+++ b/.github/workflows/wasmtime.yml
@@ -16,7 +16,9 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y php-cli php-dev php-pear pkg-config build-essential libffi-dev libssl-dev curl wabt
+          sudo apt-get install -y \
+            php-cli php-dev php-pear pkg-config build-essential libffi-dev \
+            libssl-dev curl wabt
           curl https://sh.rustup.rs -sSf | sh -s -- -y
           echo "$HOME/.cargo/bin" >> $GITHUB_PATH
 
@@ -27,4 +29,19 @@ jobs:
       - name: Run examples
         working-directory: wasmtime
         run: |
-          LD_LIBRARY_PATH=$(pwd)/wasmtime-v0.32.0-x86_64-linux-c-api/lib php -d extension=$(pwd)/modules/wasmtime.so run.php
+          LD_LIBRARY_PATH=$(pwd)/wasmtime-v35.0.0-x86_64-linux-c-api/lib \
+            php -d extension=$(pwd)/modules/wasmtime.so run.php
+
+      - name: Run python.wasm
+        working-directory: wasmtime
+        run: |
+          BASE_URL=https://github.com/antmicro/python-wasi/releases/download/v0.1.3
+          curl -L -o python3.wasm $BASE_URL/python3.wasm
+          curl -L -o python.tar.gz $BASE_URL/python.tar.gz
+          mkdir -p wasi-python/opt/wasi-python/bin \
+                     wasi-python/opt/wasi-python/lib
+          tar -xf python.tar.gz -C wasi-python/opt/wasi-python/lib
+          mkdir -p wasi-python/opt/wasi-python/lib/python3.10/lib-dynload
+          mv python3.wasm wasi-python/opt/wasi-python/bin/
+          LD_LIBRARY_PATH=$(pwd)/wasmtime-v35.0.0-x86_64-linux-c-api/lib \
+            php -d extension=$(pwd)/modules/wasmtime.so python-wasi.php

--- a/wasmtime/build.sh
+++ b/wasmtime/build.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 set -e
-VERSION=v0.32.0
+VERSION=v35.0.0
 if [ ! -d "wasmtime-$VERSION-x86_64-linux-c-api" ]; then
   curl -LO https://github.com/bytecodealliance/wasmtime/releases/download/$VERSION/wasmtime-$VERSION-x86_64-linux-c-api.tar.xz
   tar -xf wasmtime-$VERSION-x86_64-linux-c-api.tar.xz

--- a/wasmtime/python-wasi.php
+++ b/wasmtime/python-wasi.php
@@ -1,0 +1,19 @@
+<?php
+$dir = __DIR__ . '/wasi-python';
+$wasm = file_get_contents($dir . '/opt/wasi-python/bin/python3.wasm');
+$code = "print('Hello from python.wasm')";
+
+$inst = new Wasmtime\Instance($wasm, [], [
+    'wasi' => [
+        'dir'  => $dir,
+        'env'  => [
+            'PYTHONHOME' => '/opt/wasi-python',
+            'PYTHONPATH' => '/opt/wasi-python/lib/python3.10',
+        ],
+        // Execute code passed via CLI arguments to avoid file lookup issues.
+        'args' => ['python3.wasm', '-c', $code],
+    ],
+]);
+
+$inst->call('_start');
+?>

--- a/wasmtime/wasmtime.c
+++ b/wasmtime/wasmtime.c
@@ -391,7 +391,6 @@ PHP_METHOD(Wasmtime_Instance, __construct)
                         HashTable *wasi_ht = (Z_TYPE_P(wasi) == IS_ARRAY) ? Z_ARRVAL_P(wasi) : NULL;
                         wasi_config_t *cfg = wasi_config_new();
                         if (!cfg) { zend_throw_exception(zend_ce_exception, "wasi_config_new failed", 0); return; }
-                        /* inherit stdio/env/argv for simplicity */
                         wasi_config_inherit_stdin(cfg);
                         wasi_config_inherit_stdout(cfg);
                         wasi_config_inherit_stderr(cfg);
@@ -400,7 +399,41 @@ PHP_METHOD(Wasmtime_Instance, __construct)
                         if (wasi_ht) {
                                 zval *dir = zend_hash_str_find(wasi_ht, "dir", sizeof("dir")-1);
                                 if (dir && Z_TYPE_P(dir) == IS_STRING) {
-                                        wasi_config_preopen_dir(cfg, Z_STRVAL_P(dir), "/");
+                                        wasi_config_preopen_dir(cfg, Z_STRVAL_P(dir), "/",
+                                                WASMTIME_WASI_DIR_PERMS_READ | WASMTIME_WASI_DIR_PERMS_WRITE,
+                                                WASMTIME_WASI_FILE_PERMS_READ | WASMTIME_WASI_FILE_PERMS_WRITE);
+                                }
+                                zval *env = zend_hash_str_find(wasi_ht, "env", sizeof("env")-1);
+                                if (env && Z_TYPE_P(env) == IS_ARRAY) {
+                                        int envc = zend_hash_num_elements(Z_ARRVAL_P(env));
+                                        const char **names = safe_emalloc(envc, sizeof(char*), 0);
+                                        const char **values = safe_emalloc(envc, sizeof(char*), 0);
+                                        int idx = 0;
+                                        zend_string *ekey;
+                                        zval *eval;
+                                        ZEND_HASH_FOREACH_STR_KEY_VAL(Z_ARRVAL_P(env), ekey, eval) {
+                                                if (ekey && Z_TYPE_P(eval) == IS_STRING) {
+                                                        names[idx] = ZSTR_VAL(ekey);
+                                                        values[idx] = Z_STRVAL_P(eval);
+                                                        idx++;
+                                                }
+                                        } ZEND_HASH_FOREACH_END();
+                                        wasi_config_set_env(cfg, idx, names, values);
+                                        efree(names);
+                                        efree(values);
+                                }
+                                zval *args = zend_hash_str_find(wasi_ht, "args", sizeof("args")-1);
+                                if (args && Z_TYPE_P(args) == IS_ARRAY) {
+                                        int argc = zend_hash_num_elements(Z_ARRVAL_P(args));
+                                        const char **argv = safe_emalloc(argc, sizeof(char*), 0);
+                                        int idx = 0;
+                                        zval *arg;
+                                        ZEND_HASH_FOREACH_VAL(Z_ARRVAL_P(args), arg) {
+                                                convert_to_string_ex(arg);
+                                                argv[idx++] = Z_STRVAL_P(arg);
+                                        } ZEND_HASH_FOREACH_END();
+                                        wasi_config_set_argv(cfg, argc, argv);
+                                        efree(argv);
                                 }
                         }
                         wasmtime_context_t *cx = wasmtime_store_context(o->store);


### PR DESCRIPTION
## Summary
- run python-wasi hello world in Wasmtime workflow using Wasmtime PHP extension
- allow Wasmtime PHP extension to set WASI env vars and argv
- upgrade Wasmtime C API to v35.0.0 and adjust extension to new WASI APIs
- configure Python WASI layout for `/opt/wasi-python` and set PYTHONHOME/PYTHONPATH
- execute inline Python via the WASI build using CLI args

## Testing
- `php -l wasmtime/python-wasi.php`
- `yamllint .github/workflows/wasmtime.yml`
- `cd wasmtime && ./build.sh`


------
https://chatgpt.com/codex/tasks/task_e_68989ae4450883289d4bf81b78a31d9e