### PR TITLE
Add script to compile ImageMagick to WebAssembly

### DIFF
--- a/.github/workflows/build-imagemagick-wasm.yml
+++ b/.github/workflows/build-imagemagick-wasm.yml
@@ -1,0 +1,25 @@
+name: build-imagemagick-wasm
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup Emscripten
+        uses: mymindstorm/setup-emsdk@v12
+        with:
+          version: 3.1.45
+          actions-cache-key: emsdk-cache
+      - name: Build ImageMagick WASM
+        run: scripts/build_imagemagick_wasm.sh
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: imagemagick-wasm
+          path: dist/imagemagick.wasm

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,7 @@
 .cache/phpcs.cache
 /phpunit.xml
 /.phpunit.result.cache
+
+dist/
+build/
+

--- a/scripts/build_imagemagick_wasm.sh
+++ b/scripts/build_imagemagick_wasm.sh
@@ -13,6 +13,13 @@ ZLIB_VER=1.3.1
 LIBPNG_VER=1.6.43
 IMAGEMAGICK_VER=7.1.2-3
 
+# Ensure Emscripten tools are used for all builds
+export CC=emcc
+export CXX=em++
+export AR=emar
+export RANLIB=emranlib
+unset LIBS
+
 # Fetch and build zlib
 if [ ! -d zlib-$ZLIB_VER ]; then
   curl -LO https://zlib.net/zlib-$ZLIB_VER.tar.gz
@@ -43,11 +50,21 @@ if [ ! -d ImageMagick-$IMAGEMAGICK_VER ]; then
 fi
 cd ImageMagick-$IMAGEMAGICK_VER
 export CPPFLAGS="-I$BUILD_DIR/zlib-install/include -I$BUILD_DIR/libpng-install/include"
-export LDFLAGS="$BUILD_DIR/zlib-install/lib/libz.a $BUILD_DIR/libpng-install/lib/libpng16.a"
-emconfigure ./configure --disable-shared --enable-static --without-magick-plus-plus --without-perl --without-x --without-jpeg --host=wasm32-unknown-emscripten >/dev/null
+export LDFLAGS="-L$BUILD_DIR/zlib-install/lib -L$BUILD_DIR/libpng-install/lib"
+export LIBS="-lz -lpng16"
+# Remove stray configure lines that break under Emscripten
+sed -i "/^='-fPIC'/d" configure
+emconfigure ./configure \
+  --disable-shared \
+  --enable-static \
+  --without-magick-plus-plus \
+  --without-perl \
+  --without-x \
+  --without-jpeg \
+  --host=wasm32-unknown-emscripten >/dev/null
 emmake make >/dev/null
 
 # Link to wasm
-emcc MagickWand/.libs/libMagickWand-7.Q16HDRI.a MagickCore/.libs/libMagickCore-7.Q16HDRI.a $LDFLAGS -s STANDALONE_WASM=1 -o "$DIST_DIR/imagemagick.wasm"
+emcc MagickWand/.libs/libMagickWand-7.Q16HDRI.a MagickCore/.libs/libMagickCore-7.Q16HDRI.a $LDFLAGS $LIBS -s STANDALONE_WASM=1 -o "$DIST_DIR/imagemagick.wasm"
 
 printf "Built wasm module at %s/imagemagick.wasm\n" "$DIST_DIR"

--- a/scripts/build_imagemagick_wasm.sh
+++ b/scripts/build_imagemagick_wasm.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+set -eo pipefail
+
+# Build ImageMagick and its dependencies to WebAssembly using Emscripten
+
+ROOT_DIR=$(pwd)
+BUILD_DIR="$ROOT_DIR/build/imagemagick-wasm"
+DIST_DIR="$ROOT_DIR/dist"
+mkdir -p "$BUILD_DIR" "$DIST_DIR"
+cd "$BUILD_DIR"
+
+ZLIB_VER=1.3.1
+LIBPNG_VER=1.6.43
+IMAGEMAGICK_VER=7.1.2-3
+
+# Fetch and build zlib
+if [ ! -d zlib-$ZLIB_VER ]; then
+  curl -LO https://zlib.net/zlib-$ZLIB_VER.tar.gz
+  tar xf zlib-$ZLIB_VER.tar.gz
+fi
+cd zlib-$ZLIB_VER
+emconfigure ./configure --static --prefix=$PWD/../zlib-install >/dev/null
+emmake make install >/dev/null
+cd ..
+
+# Fetch and build libpng
+if [ ! -d libpng-$LIBPNG_VER ]; then
+  curl -LO https://download.sourceforge.net/libpng/libpng-$LIBPNG_VER.tar.gz
+  tar xf libpng-$LIBPNG_VER.tar.gz
+fi
+cd libpng-$LIBPNG_VER
+CPPFLAGS="-I$BUILD_DIR/zlib-install/include" LDFLAGS="-L$BUILD_DIR/zlib-install/lib" \
+  emconfigure ./configure --host=wasm32-unknown-emscripten --prefix=$PWD/../libpng-install \
+  --enable-static --disable-shared >/dev/null
+emmake make >/dev/null
+emmake make install >/dev/null
+cd ..
+
+# Fetch and build ImageMagick
+if [ ! -d ImageMagick-$IMAGEMAGICK_VER ]; then
+  curl -LO https://download.imagemagick.org/ImageMagick/download/releases/ImageMagick-$IMAGEMAGICK_VER.tar.gz
+  tar xf ImageMagick-$IMAGEMAGICK_VER.tar.gz
+fi
+cd ImageMagick-$IMAGEMAGICK_VER
+export CPPFLAGS="-I$BUILD_DIR/zlib-install/include -I$BUILD_DIR/libpng-install/include"
+export LDFLAGS="$BUILD_DIR/zlib-install/lib/libz.a $BUILD_DIR/libpng-install/lib/libpng16.a"
+emconfigure ./configure --disable-shared --enable-static --without-magick-plus-plus --without-perl --without-x --without-jpeg --host=wasm32-unknown-emscripten >/dev/null
+emmake make >/dev/null
+
+# Link to wasm
+emcc MagickWand/.libs/libMagickWand-7.Q16HDRI.a MagickCore/.libs/libMagickCore-7.Q16HDRI.a $LDFLAGS -s STANDALONE_WASM=1 -o "$DIST_DIR/imagemagick.wasm"
+
+printf "Built wasm module at %s/imagemagick.wasm\n" "$DIST_DIR"

--- a/scripts/build_imagemagick_wasm.sh
+++ b/scripts/build_imagemagick_wasm.sh
@@ -65,6 +65,7 @@ emconfigure ./configure \
 emmake make >/dev/null
 
 # Link to wasm
-emcc MagickWand/.libs/libMagickWand-7.Q16HDRI.a MagickCore/.libs/libMagickCore-7.Q16HDRI.a $LDFLAGS $LIBS -s STANDALONE_WASM=1 -o "$DIST_DIR/imagemagick.wasm"
+emcc MagickWand/.libs/libMagickWand-7.Q16HDRI.a MagickCore/.libs/libMagickCore-7.Q16HDRI.a \
+  $LDFLAGS $LIBS --no-entry -sSTANDALONE_WASM=1 -o "$DIST_DIR/imagemagick.wasm"
 
 printf "Built wasm module at %s/imagemagick.wasm\n" "$DIST_DIR"


### PR DESCRIPTION
## Summary
- replace libmagic wasm script with `scripts/build_imagemagick_wasm.sh` to build ImageMagick and minimal deps (zlib, libpng) to WASM

## Testing
- `scripts/build_imagemagick_wasm.sh` *(fails: configure: line 20250: =-fPIC: command not found)*
- `composer install` *(fails: phpunit/phpunit requires PHP <8)*

------
https://chatgpt.com/codex/tasks/task_e_68b9e1159614832883425c205bdcbc56